### PR TITLE
demo: Allow passing in 8bit as an argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,11 @@ python app.py $base_model $lora_model
 | Baize-13B | 28GB                     |
 | Baize-30B | 67GB                     |
 
-If you have a GPU with smaller VRAM, you can do inference with `int8`, following [this issue](https://github.com/project-baize/baize/issues/15).
+If you have a GPU with smaller VRAM, you can do inference with `int8`, by passing the 8bit argument:
+
+```bash
+python app.py $base_model $lora_model 8bit
+```
 
 ## How to Reproduce
 

--- a/demo/app.py
+++ b/demo/app.py
@@ -13,9 +13,15 @@ logging.basicConfig(
     format="%(asctime)s [%(levelname)s] [%(filename)s:%(lineno)d] %(message)s",
 )
 
+load_8bit = (
+    sys.argv[3].lower().startswith("8")
+    if len(sys.argv) > 3 else False
+)
 base_model = sys.argv[1]
 adapter_model = sys.argv[2]
-tokenizer, model, device = load_tokenizer_and_model(base_model, adapter_model)
+tokenizer, model, device = load_tokenizer_and_model(
+    base_model, adapter_model, load_8bit=load_8bit
+)
 
 
 def predict(


### PR DESCRIPTION
Example usage:

```
  python app.py \
      decapoda-research/llama-7b-hf \
      project-baize/baize-lora-7B \
      8bit
```